### PR TITLE
Fix wrong method name

### DIFF
--- a/test/does-file-exist.test.js
+++ b/test/does-file-exist.test.js
@@ -16,7 +16,7 @@ describe("doesFileExist", function() {
             // fs: {
             //     existsSync: existsSyncStub
             "../lib/mytools": {
-                xmlParse: existsSyncStub
+                xmlParser: existsSyncStub
             }
         });
     });


### PR DESCRIPTION
You missed one letter ...

```
$ npm test

> sinon-demo-proxyquire@1.0.0 test /tmp/node-test-demo
> mocha



  doesFileExist
    when a path exists
call doesFileExist
call doesFileExist
testRet:true
testRet2:2
      ✓ should return `true`


  1 passing (10ms)

```